### PR TITLE
Add tcllibc build step

### DIFF
--- a/developer-mode/builds/build-all.sh
+++ b/developer-mode/builds/build-all.sh
@@ -4,6 +4,7 @@ sh /builds/build-tclx.sh
 sh /builds/build-sqlite3.sh
 sh /builds/build-tcllib.sh
 sh /builds/build-critcl.sh
+sh /builds/build-tcllibc.sh
 sh /builds/build-tcllauncher.sh
 sh /builds/build-itcl.sh
 sh /builds/build-tclreadline.sh

--- a/developer-mode/builds/build-tcllib.sh
+++ b/developer-mode/builds/build-tcllib.sh
@@ -21,8 +21,5 @@ mv mime.tcl modules/mime/mime.tcl
 make
 make install
 
-/usr/bin/tclsh8.6 sak.tcl critcl
-cp -r modules/tcllibc /usr/lib/tcllibc
-
 build_cleanup
 

--- a/developer-mode/builds/build-tcllib.sh
+++ b/developer-mode/builds/build-tcllib.sh
@@ -21,5 +21,8 @@ mv mime.tcl modules/mime/mime.tcl
 make
 make install
 
+/usr/bin/tclsh8.6 sak.tcl critcl
+cp -r modules/tcllibc /usr/lib/tcllibc
+
 build_cleanup
 

--- a/developer-mode/builds/build-tcllibc.sh
+++ b/developer-mode/builds/build-tcllibc.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -e
+. /builds/common.sh
+
+build_setup
+
+if [ ! -d /workspaces/tcllib ]; then
+	cd /workspaces && sh /builds/download-tcllib.sh
+fi
+
+cd /workspaces/tcllib
+# Build the critcl components of tcllib
+/usr/bin/tclsh8.6 sak.tcl critcl
+cp -r modules/tcllibc /usr/lib/tcllibc
+
+build_cleanup
+

--- a/developer-mode/builds/download-zookeepertcl.sh
+++ b/developer-mode/builds/download-zookeepertcl.sh
@@ -1,1 +1,1 @@
-git clone -b v1.1.0 https://github.com/flightaware/zookeepertcl.git
+git clone -b v1.1.1 https://github.com/flightaware/zookeepertcl.git


### PR DESCRIPTION
* Add a build step for tcllibc after critcl is installed (tcllib needs to be installed before critcl, so we have to do it in two steps)
* Bump zookeepertcl to v1.1.1 to pick up a fix for a potential race condition