### PR TITLE
Use pip to install cmake (currently 3.17)

### DIFF
--- a/developer-mode/setup-docker-env.sh
+++ b/developer-mode/setup-docker-env.sh
@@ -1,12 +1,14 @@
 apt-get update -qq
 
 apt-get install -y git gcc-8 g++-8 make curl automake autoconf \
-    minizip vim libreadline-dev libtool cmake libyajl-dev \
+    minizip vim libreadline-dev libtool python3-pip libyajl-dev \
     libssl-dev openssl libpq-dev libzookeeper-mt-dev \
     libboost-all-dev libuv1-dev swig3.0 \
     libgd-dev pkg-config gdb libcurl4-openssl-dev \
     libmemcached-dev libxml2-dev libxslt-dev apache2-dev apache2 \
     libgeos-dev libproj-dev libbsd-dev
+
+pip3 install cmake
 
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 update-alternatives --set cc /usr/bin/gcc-8

--- a/developer-mode/setup-docker-env.sh
+++ b/developer-mode/setup-docker-env.sh
@@ -1,9 +1,9 @@
 apt-get update -qq
 
 apt-get install -y git gcc-8 g++-8 make curl automake autoconf \
-    minizip vim libreadline-dev libtool python3-pip libyajl-dev \
+    minizip vim libreadline-dev libtool python3-pip python3-venv \
     libssl-dev openssl libpq-dev libzookeeper-mt-dev \
-    libboost-all-dev libuv1-dev swig3.0 \
+    libboost-all-dev libuv1-dev swig3.0 libyajl-dev \
     libgd-dev pkg-config gdb libcurl4-openssl-dev \
     libmemcached-dev libxml2-dev libxslt-dev apache2-dev apache2 \
     libgeos-dev libproj-dev libbsd-dev

--- a/developer-mode/setup-docker-env.sh
+++ b/developer-mode/setup-docker-env.sh
@@ -8,11 +8,10 @@ apt-get install -y git gcc-8 g++-8 make curl automake autoconf \
     libmemcached-dev libxml2-dev libxslt-dev apache2-dev apache2 \
     libgeos-dev libproj-dev libbsd-dev
 
-pip3 install cmake
+pip3 install "cmake==3.17.2"
 
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 update-alternatives --set cc /usr/bin/gcc-8
 update-alternatives --set c++ /usr/bin/g++-8
 
 dpkg-query -l 2>&1 | sed "s,^,package-selections: ,"
-


### PR DESCRIPTION
* Debian buster only has cmake 3.13 and there are some nice features in later versions of cmake.  Pip now installs cmake 3.17 so install pip3 and use it to install cmake