### PR TITLE
Final image expects tmp base image developer-mode

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build dev image
         run: |
           mkdir build
-          docker build -t tcl-2020-dev developer-mode
+          docker build -t developer-mode developer-mode
 
       - name: Build image
         run: docker build . --file shell/Dockerfile --tag $IMAGE_NAME

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Build dev image
         run: |
           mkdir build
-          docker build -t tcl-2020-dev developer-mode
+          docker build -t tcl-2020-dev:$GITHUB_RUN_ID developer-mode
 
       - name: Build image
-        run: docker build . --file shell/Dockerfile --tag $IMAGE_NAME
+        run: docker build . --file shell/Dockerfile --build-arg IMAGE_TAG=$GITHUB_RUN_ID --tag $IMAGE_NAME
 
       - name: Log into registry
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ secrets.GHCR_USER }} --password-stdin

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build dev image
         run: |
           mkdir build
-          docker build -t developer-mode developer-mode
+          docker build -t tcl-2020-dev developer-mode
 
       - name: Build image
         run: docker build . --file shell/Dockerfile --tag $IMAGE_NAME

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -1,4 +1,5 @@
-FROM tcl-2020-dev:latest
+ARG IMAGE_TAG=latest
+FROM tcl-2020-dev:$IMAGE_TAG
 
 LABEL org.opencontainers.image.source https://github.com/tcl2020/tcl2020-build
 

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -1,4 +1,4 @@
-FROM tcl2020/developer-mode:latest
+FROM tcl-2020-dev:latest
 
 LABEL org.opencontainers.image.source https://github.com/tcl2020/tcl2020-build
 


### PR DESCRIPTION
* Tag the dev image with the github run id, instead of latest, so it is uniquely identifiable
* Update the `shell/Dockerfile` to build on the `tcl-2020-dev` image built in the previous step of the github action workflow for tagged versions, using the unique run id to ensure that image is used. Makes use of a docker ARG to determine that tag dynamically