### PR TITLE
Build spatialite in /usr/local

### DIFF
--- a/developer-mode/builds/build-libspatialite.sh
+++ b/developer-mode/builds/build-libspatialite.sh
@@ -17,7 +17,7 @@ else
 fi
 cd "/workspaces/libspatialite/$BUILD_VERSION/" || exit 1
 autoreconf -vi
-./configure --prefix=/usr --exec-prefix=/usr --disable-freexl
+./configure --prefix=/usr/local --exec-prefix=/usr/local --disable-freexl
 make && make install
 
 build_cleanup


### PR DESCRIPTION
sqlite fails to locate mod_spatialite without shenanigans if it's not in /usr/local