### PR TITLE
BCK-5661 - make sure build fails if individual builds fail.

### DIFF
--- a/developer-mode/builds/build-all.sh
+++ b/developer-mode/builds/build-all.sh
@@ -1,4 +1,5 @@
 set -e
+
 sh /builds/build-tcl.sh
 sh /builds/build-tclx.sh
 sh /builds/build-sqlite3.sh

--- a/developer-mode/builds/build-casstcl.sh
+++ b/developer-mode/builds/build-casstcl.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup
@@ -16,7 +18,7 @@ make install
 
 cd /workspaces/casstcl || exit 1
 autoreconf --force --install --verbose
-./configure  --with-tcl=/usr/lib --with-tclinclude=/usr/include 
+./configure  --with-tcl=/usr/lib --with-tclinclude=/usr/include
 make && make install
 
 build_cleanup

--- a/developer-mode/builds/build-cpptcl.sh
+++ b/developer-mode/builds/build-cpptcl.sh
@@ -7,7 +7,7 @@ if [ ! -d /workspaces/cpptcl ]; then
     cd /workspaces && sh /builds/download-cpptcl.sh
 fi
 
-cd /workspaces/cpptcl && make clean && make && make install
+cd /workspaces/cpptcl ; make clean ; make ; make install
 
 build_cleanup
 

--- a/developer-mode/builds/build-cpptcl.sh
+++ b/developer-mode/builds/build-cpptcl.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-critcl.sh
+++ b/developer-mode/builds/build-critcl.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-itcl.sh
+++ b/developer-mode/builds/build-itcl.sh
@@ -12,8 +12,8 @@ cd /workspaces/itcl || exit 1
 # iTcl does not have the TEA files
 # copy them from another project for now
 # we should checkout TEA and use that
-mkdir tclconfig && cp ../tcllauncher/tclconfig/* tclconfig
-./configure && make all && make install
+mkdir tclconfig ; cp ../tcllauncher/tclconfig/* tclconfig/.
+./configure ; make all ; make install
 
 build_cleanup
 

--- a/developer-mode/builds/build-itcl.sh
+++ b/developer-mode/builds/build-itcl.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-kafkatcl.sh
+++ b/developer-mode/builds/build-kafkatcl.sh
@@ -8,11 +8,11 @@ if [ ! -d /workspaces/kafkatcl ]; then
 fi
 
 cd /workspaces/librdkafka || exit 1
-./configure && make && make install && ldconfig
+./configure ; make ; make install ; ldconfig
 
 cd /workspaces/kafkatcl || exit 1
 autoreconf --force --install --verbose
 ./configure  --with-tcl=/usr/lib --with-tclinclude=/usr/include
-make && make install
+make ; make install
 
 build_cleanup

--- a/developer-mode/builds/build-kafkatcl.sh
+++ b/developer-mode/builds/build-kafkatcl.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-libspatialite.sh
+++ b/developer-mode/builds/build-libspatialite.sh
@@ -18,6 +18,6 @@ fi
 cd "/workspaces/libspatialite/$BUILD_VERSION/" || exit 1
 autoreconf -vi
 ./configure --prefix=/usr/local --exec-prefix=/usr/local --disable-freexl
-make && make install
+make ; make install
 
 build_cleanup

--- a/developer-mode/builds/build-libspatialite.sh
+++ b/developer-mode/builds/build-libspatialite.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-memcached-for-Tcl.sh
+++ b/developer-mode/builds/build-memcached-for-Tcl.sh
@@ -7,9 +7,9 @@ if [ ! -d /workspaces/memcached-for-Tcl ]; then
     cd /workspaces && sh /builds/download-memcached-for-Tcl.sh
 fi
 
-cd /workspaces/memcached-for-Tcl && \
-    autoreconf -vi && \
-    ./configure && make && make install
+cd /workspaces/memcached-for-Tcl
+autoreconf -vi
+./configure ; make ; make install
 
 build_cleanup
 

--- a/developer-mode/builds/build-memcached-for-Tcl.sh
+++ b/developer-mode/builds/build-memcached-for-Tcl.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-pgtcl.sh
+++ b/developer-mode/builds/build-pgtcl.sh
@@ -10,6 +10,6 @@ fi
 cd /workspaces/Pgtcl || exit 1
 autoreconf --force --install --verbose
 ./configure  --with-tcl=/usr/lib --with-tclinclude=/usr/include --with-postgres-include=/usr/include/postgresql --with-postgres-lib=/usr/lib/x86_64-linux-gnu
-make && make install
+make ; make install
 
 build_cleanup

--- a/developer-mode/builds/build-pgtcl.sh
+++ b/developer-mode/builds/build-pgtcl.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-rl_json.sh
+++ b/developer-mode/builds/build-rl_json.sh
@@ -10,6 +10,6 @@ fi
 cd /workspaces/rl_json || exit 1
 #autoreconf --force --install --verbose
 ./configure  --with-tcl=/usr/lib --with-tclinclude=/usr/include
-make && make install
+make ; make install
 
 build_cleanup

--- a/developer-mode/builds/build-rl_json.sh
+++ b/developer-mode/builds/build-rl_json.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-s6.sh
+++ b/developer-mode/builds/build-s6.sh
@@ -10,8 +10,8 @@ fi
 
 cd /workspaces/s6 || exit 1
 
-cd skalibs && ./configure && make && make install && \
-cd ../execline && ./configure && make && make install && \
-cd ../s6 && ./configure && make && make install
+cd skalibs ; ./configure ; make ; make install 
+cd ../execline ; ./configure ; make ; make install
+cd ../s6 ; ./configure ; make ; make install
 
 build_cleanup

--- a/developer-mode/builds/build-s6.sh
+++ b/developer-mode/builds/build-s6.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup
@@ -10,7 +12,7 @@ fi
 
 cd /workspaces/s6 || exit 1
 
-cd skalibs ; ./configure ; make ; make install 
+cd skalibs ; ./configure ; make ; make install
 cd ../execline ; ./configure ; make ; make install
 cd ../s6 ; ./configure ; make ; make install
 

--- a/developer-mode/builds/build-scotty-tnm.sh
+++ b/developer-mode/builds/build-scotty-tnm.sh
@@ -8,8 +8,8 @@ if [ ! -d /workspaces/scotty ]; then
 fi
 
 cd /workspaces/scotty/tnm || exit 1
-autoreconf --force --install --verbose && \
-./configure && make && make install && make sinstall
+autoreconf --force --install --verbose 
+./configure ; make ; make install ; make sinstall
 
 build_cleanup
 

--- a/developer-mode/builds/build-scotty-tnm.sh
+++ b/developer-mode/builds/build-scotty-tnm.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup
@@ -8,7 +10,7 @@ if [ ! -d /workspaces/scotty ]; then
 fi
 
 cd /workspaces/scotty/tnm || exit 1
-autoreconf --force --install --verbose 
+autoreconf --force --install --verbose
 ./configure ; make ; make install ; make sinstall
 
 build_cleanup

--- a/developer-mode/builds/build-socketservertcl.sh
+++ b/developer-mode/builds/build-socketservertcl.sh
@@ -10,6 +10,6 @@ fi
 cd /workspaces/socketservertcl || exit 1
 autoreconf --force --install --verbose
 ./configure  --with-tcl=/usr/lib --with-tclinclude=/usr/include
-make && make install
+make ; make install
 
 build_cleanup

--- a/developer-mode/builds/build-socketservertcl.sh
+++ b/developer-mode/builds/build-socketservertcl.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-spdlog.sh
+++ b/developer-mode/builds/build-spdlog.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-speedbag.sh
+++ b/developer-mode/builds/build-speedbag.sh
@@ -10,6 +10,6 @@ fi
 cd /workspaces/speedbag || exit 1
 autoreconf --force --install --verbose
 ./configure  --with-tcl=/usr/lib --with-tclinclude=/usr/include
-make && make install
+make ; make install
 
 build_cleanup

--- a/developer-mode/builds/build-speedbag.sh
+++ b/developer-mode/builds/build-speedbag.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-speedtables.sh
+++ b/developer-mode/builds/build-speedtables.sh
@@ -10,6 +10,6 @@ fi
 cd /workspaces/speedtables || exit 1
 autoreconf --force --install --verbose
 ./configure  --with-tcl=/usr/lib --with-tclinclude=/usr/include
-make clean && make && make install
+make clean ; make ; make install
 
 build_cleanup

--- a/developer-mode/builds/build-speedtables.sh
+++ b/developer-mode/builds/build-speedtables.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-sqlite3.sh
+++ b/developer-mode/builds/build-sqlite3.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-tcl-rivet.sh
+++ b/developer-mode/builds/build-tcl-rivet.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-tcl.gd.sh
+++ b/developer-mode/builds/build-tcl.gd.sh
@@ -10,6 +10,6 @@ fi
 cd /workspaces/tcl.gd || exit 1
 autoreconf --force --install --verbose
 CFLAGS="-DGD_JPEG -DGD_PNG" ./configure  --with-tcl=/usr/lib --with-tclinclude=/usr/include || exit 1
-make && make install
+make ; make install
 
 build_cleanup

--- a/developer-mode/builds/build-tcl.gd.sh
+++ b/developer-mode/builds/build-tcl.gd.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-tcl.sh
+++ b/developer-mode/builds/build-tcl.sh
@@ -1,9 +1,11 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup
 
-if [ ! -d /workspaces/tcl ]; then 
+if [ ! -d /workspaces/tcl ]; then
     cd /workspaces && sh /builds/download-tcl.sh
 fi
 
@@ -28,7 +30,7 @@ if [ ! -f /bin/tclsh ]; then
 fi
 if [ ! -f /usr/bin/tclsh ]; then
     ln /usr/bin/tclsh8.6 /usr/bin/tclsh
-fi 
+fi
 
 build_cleanup
 

--- a/developer-mode/builds/build-tclbsd.sh
+++ b/developer-mode/builds/build-tclbsd.sh
@@ -8,7 +8,7 @@ if [ ! -d /workspaces/tclbsd ]; then
 fi
 
 cd /workspaces/tclbsd || exit 1
-autoreconf -vi && ./configure && make && make install
+autoreconf -vi ; ./configure ; make ; make install
 
 build_cleanup
 

--- a/developer-mode/builds/build-tclbsd.sh
+++ b/developer-mode/builds/build-tclbsd.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-tclclockmod.sh
+++ b/developer-mode/builds/build-tclclockmod.sh
@@ -10,6 +10,6 @@ fi
 . $TCL_CONFIG
 export LIBS="$TCL_LIBS"
 
-cd /workspaces/tclclockmod && autoreconf -vi && ./configure && make && make install
+cd /workspaces/tclclockmod ; autoreconf -vi ; ./configure ; make ; make install
 
 build_cleanup

--- a/developer-mode/builds/build-tclclockmod.sh
+++ b/developer-mode/builds/build-tclclockmod.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-tclcurl-fa.sh
+++ b/developer-mode/builds/build-tclcurl-fa.sh
@@ -7,7 +7,7 @@ if [ ! -d /workspaces/tclcurl-fa ]; then
     cd /workspaces && sh /builds/download-tclcurl-fa.sh
 fi
 
-cd /workspaces/tclcurl-fa && ./configure --enable-threads && make && make install
+cd /workspaces/tclcurl-fa ; ./configure --enable-threads ; make ; make install
 
 build_cleanup
 

--- a/developer-mode/builds/build-tclcurl-fa.sh
+++ b/developer-mode/builds/build-tclcurl-fa.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-tcllauncher.sh
+++ b/developer-mode/builds/build-tcllauncher.sh
@@ -10,7 +10,7 @@ fi
 . $TCL_CONFIG
 export LIBS="$TCL_LIBS"
 
-cd /workspaces/tcllauncher && autoreconf -vi && ./configure && make && make install
+cd /workspaces/tcllauncher ; autoreconf -vi ; ./configure ; make ; make install
 
 build_cleanup
 

--- a/developer-mode/builds/build-tcllauncher.sh
+++ b/developer-mode/builds/build-tcllauncher.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-tcllib.sh
+++ b/developer-mode/builds/build-tcllib.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup
@@ -16,7 +18,7 @@ cd /workspaces/tcllib
 echo "Building Tcllib"
 # patch out -- in proc arguments for named parameters
 cat modules/mime/mime.tcl | sed 's,what --,what ignore,' | sed 's,-- string,ignore string,' >mime.tcl
-diff modules/mime/mime.tcl mime.tcl
+diff modules/mime/mime.tcl mime.tcl || true
 mv mime.tcl modules/mime/mime.tcl
 make
 make install

--- a/developer-mode/builds/build-tcllibc.sh
+++ b/developer-mode/builds/build-tcllibc.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-tclreadline.sh
+++ b/developer-mode/builds/build-tclreadline.sh
@@ -10,7 +10,7 @@ fi
 . $TCL_CONFIG
 export LIBS="$TCL_LIBS"
 
-cd /workspaces/tclreadline && autoreconf -vi && ./configure --with-tk=no && make && make install
+cd /workspaces/tclreadline ; autoreconf -vi ; ./configure --with-tk=no ; make ; make install
 
 build_cleanup
 

--- a/developer-mode/builds/build-tclreadline.sh
+++ b/developer-mode/builds/build-tclreadline.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-tclrmq.sh
+++ b/developer-mode/builds/build-tclrmq.sh
@@ -1,9 +1,11 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup
 
-if [ ! -d /workspaces/tclrmq ]; then 
+if [ ! -d /workspaces/tclrmq ]; then
 	cd /workspaces && sh /builds/download-tclrmq.sh
 fi
 

--- a/developer-mode/builds/build-tcltk-thread.sh
+++ b/developer-mode/builds/build-tcltk-thread.sh
@@ -10,7 +10,7 @@ fi
 cd /workspaces/thread
 # TODO replace this copy of tclconfig
 mkdir tclconfig && cp ../tcllauncher/tclconfig/* tclconfig
-./configure && make && make install
+./configure ; make ; make install
 
 build_cleanup
 

--- a/developer-mode/builds/build-tcltk-thread.sh
+++ b/developer-mode/builds/build-tcltk-thread.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-tcltls.sh
+++ b/developer-mode/builds/build-tcltls.sh
@@ -16,7 +16,7 @@ else
 	echo "Building /workspaces/tcltls/$BUILD_VERSION"
 fi
 cd "/workspaces/tcltls/$BUILD_VERSION/" || exit 1
-./configure --with-openssl-dir=/usr/lib/ssl && make && make install
+./configure --with-openssl-dir=/usr/lib/ssl ; make ; make install
 
 build_cleanup
 

--- a/developer-mode/builds/build-tcltls.sh
+++ b/developer-mode/builds/build-tcltls.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-tcludp.sh
+++ b/developer-mode/builds/build-tcludp.sh
@@ -10,6 +10,6 @@ fi
 cd /workspaces/tcludp || exit 1
 autoreconf --force --install --verbose
 ./configure  --with-tcl=/usr/lib --with-tclinclude=/usr/include
-make && make install
+make ; make install
 
 build_cleanup

--- a/developer-mode/builds/build-tcludp.sh
+++ b/developer-mode/builds/build-tcludp.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-tclx.sh
+++ b/developer-mode/builds/build-tclx.sh
@@ -1,9 +1,11 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup
 
-if [ ! -d /workspaces/tclx ]; then 
+if [ ! -d /workspaces/tclx ]; then
 	cd /workspaces && sh /builds/download-tclx.sh
 fi
 

--- a/developer-mode/builds/build-tclxml.sh
+++ b/developer-mode/builds/build-tclxml.sh
@@ -10,6 +10,6 @@ fi
 cd /workspaces/TclXML || exit 1
 autoreconf --force --install --verbose
 ./configure  --with-tcl=/usr/lib --with-tclinclude=/usr/include
-make && make install
+make ; make install
 
 build_cleanup

--- a/developer-mode/builds/build-tclxml.sh
+++ b/developer-mode/builds/build-tclxml.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-tdom.sh
+++ b/developer-mode/builds/build-tdom.sh
@@ -18,7 +18,7 @@ fi
 cd "/workspaces/tdom/$BUILD_VERSION/" || exit 1
 # TODO tdom will probably be patched at some time
 # to remove CONST84
-./configure CFLAGS='-DCONST84="const"' && make && make install
+./configure CFLAGS='-DCONST84="const"' ; make ; make install
 
 build_cleanup
 

--- a/developer-mode/builds/build-tdom.sh
+++ b/developer-mode/builds/build-tdom.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-yajl-tcl.sh
+++ b/developer-mode/builds/build-yajl-tcl.sh
@@ -8,7 +8,7 @@ if [ ! -d /workspaces/yajl-tcl ]; then
 fi
 
 cd /workspaces/yajl-tcl
-autoreconf -vi && ./configure && make && make install
+autoreconf -vi ; ./configure ; make ; make install
 
 build_cleanup
 

--- a/developer-mode/builds/build-yajl-tcl.sh
+++ b/developer-mode/builds/build-yajl-tcl.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/build-zookeepertcl.sh
+++ b/developer-mode/builds/build-zookeepertcl.sh
@@ -10,6 +10,6 @@ fi
 cd /workspaces/zookeepertcl || exit 1
 autoreconf --force --install --verbose
 ./configure  --with-tcl=/usr/lib --with-tclinclude=/usr/include
-make && make install
+make ; make install
 
 build_cleanup

--- a/developer-mode/builds/build-zookeepertcl.sh
+++ b/developer-mode/builds/build-zookeepertcl.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh
+
+set -e
 . /builds/common.sh
 
 build_setup

--- a/developer-mode/builds/common.sh
+++ b/developer-mode/builds/common.sh
@@ -31,3 +31,4 @@ build_cleanup () {
 	find $(readlink -f /workspaces) -type d -print0 | xargs -0 chmod go+rwx
 	find $(readlink -f /workspaces) -type f -print0 | xargs -0 chmod go+rw
 }
+

--- a/developer-mode/builds/download-libspatialite.sh
+++ b/developer-mode/builds/download-libspatialite.sh
@@ -1,2 +1,5 @@
 set -e
-rm -rf libspatialite && mkdir libspatialite && cd libspatialite && curl http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-5.0.0.tar.gz | tar -xzf -
+rm -rf libspatialite 
+mkdir libspatialite 
+cd libspatialite 
+curl http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-5.0.0.tar.gz | tar -xzf -

--- a/developer-mode/builds/download-s6.sh
+++ b/developer-mode/builds/download-s6.sh
@@ -1,4 +1,5 @@
-git clone -b v2.6.4.0 https://github.com/skarnet/skalibs.git && \
-git clone -b v2.7.1.1 https://github.com/skarnet/s6.git && \
+set -e
+git clone -b v2.6.4.0 https://github.com/skarnet/skalibs.git
+git clone -b v2.7.1.1 https://github.com/skarnet/s6.git
 git clone -b v2.5.0.0 https://github.com/skarnet/execline.git
 

--- a/developer-mode/builds/download-sqlite3.sh
+++ b/developer-mode/builds/download-sqlite3.sh
@@ -1,1 +1,5 @@
-rm -rf sqlite && mkdir sqlite && cd sqlite && curl https://www.sqlite.org/2022/sqlite-autoconf-3380000.tar.gz | tar -xzf -
+set -e
+rm -rf sqlite 
+mkdir sqlite 
+cd sqlite 
+curl https://www.sqlite.org/2022/sqlite-autoconf-3380000.tar.gz | tar -xzf -

--- a/developer-mode/builds/download-tcltls.sh
+++ b/developer-mode/builds/download-tcltls.sh
@@ -1,2 +1,5 @@
-mkdir -p tcltls && cd tcltls && curl -L 'https://core.tcl-lang.org/tcltls/uv/tcltls-1.7.22.tar.gz' | tar -xvzf -
+set -e
+mkdir -p tcltls 
+cd tcltls 
+curl -L 'https://core.tcl-lang.org/tcltls/uv/tcltls-1.7.22.tar.gz' | tar -xvzf -
 

--- a/developer-mode/builds/download-tdom.sh
+++ b/developer-mode/builds/download-tdom.sh
@@ -1,2 +1,5 @@
-mkdir tdom && cd tdom && curl 'http://tdom.org/downloads/tdom-0.9.1-src.tgz' | tar -xvzf -
+set -e
+mkdir tdom 
+cd tdom 
+curl 'http://tdom.org/downloads/tdom-0.9.1-src.tgz' | tar -xvzf -
 


### PR DESCRIPTION
cmd1 && cmd2 does not abort even with "set -e" if cmd1 fails, it seems to be treated *exactly* the same as "if cmd1; then cmd2; fi".

Depend on the "-e" setting to abort sequences of commands and run them independently.